### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **ManaPHP** framework monorepo (Swoole-based PHP). It contains five runnable apps plus the shared `framework/` library:
+
+| App | Type | Entry point | Notes |
+| --- | --- | --- | --- |
+| `app-api` | HTTP JSON API | `php public/index.php` | Router prefix `/api`; e.g. `curl http://127.0.0.1:9501/api` → `{"data":"Hello ManaPHP"}` |
+| `app-admin` | HTTP MVC (admin) | `php -d opcache.enable_cli=on public/index.php` | Uses MySQL + Redis; `/` redirects to `/login` |
+| `app-user` | HTTP MVC (user) | `php -d opcache.enable_cli=on public/index.php` | Uses MySQL + Redis; `/` redirects to `about` |
+| `app-ws` | WebSocket server | `php public/index.php` | **Requires the Swoole extension** (no fallback). Route `/echo` echoes payloads |
+| `app-cli` | Console app | `php manacli.php` (or `./manacli`) | Lists/runs commands; no HTTP server |
+
+### Ports
+- Every HTTP/WS server listens on **port 9501**. Only **one** app can run at a time locally unless you edit `config/server.php`.
+
+### Runtime services (must be started each session; NOT started by the update script)
+MySQL data and Redis are installed in the environment snapshot but the daemons are stopped on a fresh VM. Start them before running any app except `app-cli`:
+
+```bash
+sudo mysqld_safe --datadir=/var/lib/mysql >/tmp/mysqld.log 2>&1 &
+sudo redis-server --daemonize yes --port 6379
+```
+
+- MySQL root credentials are `root` / `123456` (matches the default `DB_URL`). Databases `manaphp` (app data, seeded from `app-admin/install.sql` + `app-user/install.sql`) and `manaphp_unit_test` (tests) already exist in the snapshot.
+- Redis runs on `localhost:6379` (apps use DB index 1).
+
+### Config files (gitignored — recreated by the update script)
+Each app boots by reading `<app>/config/.env`, which is **gitignored**. The `Kernel` throws `FileNotFoundException` if it is missing. The update script copies `<app>/config/.env.example` → `<app>/config/.env` when absent. If you change credentials/ports, edit `<app>/config/.env` (not the example).
+
+### Swoole vs pure-PHP HTTP adapter
+- `config/server.php` auto-detects the server adapter. With the Swoole extension loaded (it is, in the snapshot), HTTP apps run on the Swoole HTTP server (coroutine). Without Swoole they fall back to a pure-PHP `-S` server on 9501. `app-ws` has **no** fallback and needs Swoole.
+
+### Lint / tests
+- There is **no** dedicated linter (no phpstan/psalm/php-cs-fixer config) and **no** root `composer.json`. The only syntax check is `php -l <file>` (ignore `framework/.phpstorm.meta.php`, which is PhpStorm metadata, not code).
+- The `tests/` suite + `phpunit.xml.dist` are **legacy/stale**: `tests/bootstrap.php` requires a non-existent `ManaPHP/Loader.php`, no PHPUnit is declared as a dependency, and the assertions target old framework behavior (they fail against current code). Do not treat these as a passing gate.
+
+### vendor
+`vendor/` directories are **committed** for each app and use PSR-4 (the framework is mapped in-place via `"ManaPHP\\": "../framework/"`). New framework classes resolve automatically without `composer install`. Running `composer install` only regenerates the autoloader (the "lock file is not up to date" warnings are harmless).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the ManaPHP monorepo so all five apps (`app-api`, `app-admin`, `app-user`, `app-ws`, `app-cli`) can be built, run, and exercised end-to-end in Cursor Cloud.

This PR only adds `AGENTS.md` (durable, non-obvious run/test guidance for future cloud agents). System dependencies (PHP 8.3, Swoole, MySQL, Redis, Composer) are captured in the VM snapshot, and the startup update script recreates the gitignored `config/.env` files.

## What was installed
- PHP 8.3 (cli) + extensions: `mysqli`, `pdo_mysql`, `redis`, `gd`, `imagick`, `mbstring`, `curl`, `xml`, `bcmath`, `zip`, `intl`
- Swoole 6.2.1 (PECL build) — required by `app-ws`, used by HTTP apps
- Composer 2.10.2, MariaDB, Redis

## Update script (startup dependency refresh)
Recreates the gitignored per-app `config/.env` from `config/.env.example` and ensures `runtime/` exists:
```
for app in app-api app-admin app-user app-ws app-cli; do
  if [ -f "$app/config/.env.example" ] && [ ! -f "$app/config/.env" ]; then
    cp "$app/config/.env.example" "$app/config/.env"
  fi
  mkdir -p "$app/runtime"
done
```

## Services verified

| App | Command | Result |
| --- | --- | --- |
| app-api | `php public/index.php` | `curl :9501/api` → `{"data":"Hello ManaPHP"}` |
| app-admin | `php -d opcache.enable_cli=on public/index.php` | `/` → 302 redirect to `/login` (DB/Redis OK) |
| app-user | `php -d opcache.enable_cli=on public/index.php` | `/` → 302 redirect to `about` |
| app-ws | `php public/index.php` | WebSocket `/echo` handshake + echo + time message OK |
| app-cli | `php manacli.php` | command list rendered |

Lint: `php -l` across 971 source files passes (only `framework/.phpstorm.meta.php`, a PhpStorm metadata file, is not valid standalone PHP).

Note: the `tests/` + `phpunit.xml.dist` suite is legacy/stale (bootstrap requires a non-existent `ManaPHP/Loader.php`, no PHPUnit dependency declared, assertions target old behavior) — documented in `AGENTS.md`.

## Walkthrough
[manaphp_api_hello_world_demo.mp4](https://cursor.com/agents/bc-1d271e2e-7d00-4d89-addb-5632bfe771f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmanaphp_api_hello_world_demo.mp4)

[app-api Hello ManaPHP JSON response in browser](https://cursor.com/agents/bc-1d271e2e-7d00-4d89-addb-5632bfe771f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmanaphp_api_hello_world.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d271e2e-7d00-4d89-addb-5632bfe771f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d271e2e-7d00-4d89-addb-5632bfe771f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

